### PR TITLE
if output_file is specified as ".", then output html file to the same directory.

### DIFF
--- a/MarkdownSlideshow.py
+++ b/MarkdownSlideshow.py
@@ -31,6 +31,9 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
             opts['themes'] = os.path.join(pkg_path, 'themes')
 
         # path of the output file
+        if output_file == '.':
+            output_file = self.view.file_name() + ".html"
+
         if output_file is None:
             output_path = None
         else:


### PR DESCRIPTION
markdown-slideshow always outputs html file to the same directory or temporary directory. But if the md file contains images, the img link is not workable. 

The patch is to output html file to the same directory of the md file. 
