### PR TITLE
Allow reuse of io2012 and io2011 markup style 

### DIFF
--- a/MarkdownSlideshow.py
+++ b/MarkdownSlideshow.py
@@ -26,6 +26,7 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
         settings = sublime.load_settings('MarkdownSlideshow.sublime-settings')
         themes = settings.get('themes', None)
         theme = settings.get('theme', 'io2012')
+        theme = settings.get('theme_processor', 'io2012')
         extensions = settings.get('extensions', [])
         output_file = settings.get('output_file', None)
         clean = settings.get('clean', False)
@@ -36,6 +37,7 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
         opts = {
             'themes': themes,
             'theme': theme,
+            'theme_processor': theme_processor,
             'contents': self.view.substr(sublime.Region(0, self.view.size())),
             'extensions': extensions,
             'clean': clean

--- a/MarkdownSlideshow.py
+++ b/MarkdownSlideshow.py
@@ -26,6 +26,7 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
         settings = sublime.load_settings('MarkdownSlideshow.sublime-settings')
         themes = settings.get('themes', None)
         theme = settings.get('theme', 'io2012')
+        theme_processor = settings.get('theme_processor', 'io2012')
         extensions = settings.get('extensions', [])
         output_file = settings.get('output_file', None)
         clean = settings.get('clean', False)
@@ -36,6 +37,7 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
         opts = {
             'themes': themes,
             'theme': theme,
+            'theme_processor': theme_processor,
             'contents': self.view.substr(sublime.Region(0, self.view.size())),
             'extensions': extensions,
             'clean': clean

--- a/MarkdownSlideshow.py
+++ b/MarkdownSlideshow.py
@@ -25,12 +25,7 @@ class MarkdownSlideshowCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         settings = sublime.load_settings('MarkdownSlideshow.sublime-settings')
         themes = settings.get('themes', None)
-        theme = settings.get('theme', 'io2012')
-<<<<<<< HEAD
         theme_processor = settings.get('theme_processor', 'io2012')
-=======
-        theme = settings.get('theme_processor', 'io2012')
->>>>>>> 4241b985ff6e71af2ee95afe77789294c2188317
         extensions = settings.get('extensions', [])
         output_file = settings.get('output_file', None)
         clean = settings.get('clean', False)

--- a/MarkdownSlideshow.sublime-settings
+++ b/MarkdownSlideshow.sublime-settings
@@ -4,6 +4,9 @@
 
   // Theme of the slide. (io2012, io2011, ...)
   "theme" : "io2012",
+  
+  // Processor used to Render the slide. (io2012, io2011, ...)
+  "theme_processor" : "io2012",
 
   // Provided to expand the base syntax. (extra, fenced_code, tables, ...)
   "extensions": [],

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ $ git clone git://github.com/ogom/sublimetext-markdown-slideshow.git
   // Theme of the slide. (io2012, io2011, ...)
   "theme" : "io2012",
 
+  // Theme of the slide. (io2012, io2011, ...)
+  "theme_processor" : "io2012",
+
   // Provided to expand the base syntax. (extra, fenced_code, tables, ...)
   "extensions": [],
 

--- a/lib/mcider/converter.py
+++ b/lib/mcider/converter.py
@@ -21,6 +21,7 @@ class Slide():
     """ opts
         .themes themes path
         .theme io2012(default) or io2011
+        .theme_processor io2012(default) or io2011
         .contents
         .extensions extra fenced_code tables, ...
         .clean (boolean, default False)
@@ -31,6 +32,8 @@ class Slide():
             raise KeyError('themes')
         if 'theme' not in self.options:
             self.options['theme'] = 'io2012'
+        if 'theme_processor' not in self.options:
+            self.options['theme_processor'] = self.options['theme']
         if 'contents' not in self.options:
             self.options['contents'] = None
         if 'extensions' not in self.options:
@@ -44,7 +47,7 @@ class Slide():
     def maker(self, output_path=None):
         theme_path = os.path.abspath(os.path.join(self.options['themes'], self.options['theme']))
         template = self._get_template(output_path, theme_path, self.options['clean'])
-        slide = self._get_slide(self.options['theme'], self.options['contents'], self.options['extensions'])
+        slide = self._get_slide(self.options['theme'], self.options['theme_processor'], self.options['contents'], self.options['extensions'])
         return template.replace('{{ slide }}', slide)
 
     def _get_template(self, output_path=None, theme_path=None, clean=False):
@@ -60,11 +63,11 @@ class Slide():
                     shutil.copytree(src_path, dst_path)
         return util.fs_reader(os.path.join(theme_path, 'base.html'))
 
-    def _get_slide(self, theme=None, contents=None, extensions=[]):
+    def _get_slide(self, theme=None, theme_processor=None, contents=None, extensions=[]):
         html = None
-        if theme == 'io2011':
+        if theme_processor == 'io2011':
             html = self._get_slide_io2011(contents, extensions)
-        elif theme == 'io2012':
+        elif theme_processor == 'io2012':
             html = self._get_slide_io2012(contents, extensions)
         else:
             html = self._get_slide_none(contents, extensions)


### PR DESCRIPTION
The changes in this pull allow a user to leverage the styling for the io2012 and 2011 without having to modify the python code inside the package.

See issue #10 
